### PR TITLE
Check if helper functions exists

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -11,12 +11,15 @@
  * 
  * @return boolean
  */
-function php_cs_fixer($path, array $options = []) {
-    if (!is_array($path)) {
-        $path = [$path];
-    }
 
-    $options = array_merge($options, ['path' => $path]);
-    
-    return Artisan::call('php-cs-fixer:fix', $options);
+if (! function_exists('php_cs_fixer')) {
+  function php_cs_fixer($path, array $options = []) {
+      if (!is_array($path)) {
+          $path = [$path];
+      }
+
+      $options = array_merge($options, ['path' => $path]);
+
+      return Artisan::call('php-cs-fixer:fix', $options);
+  }
 }


### PR DESCRIPTION
With my setup i got the following error when running `php artisan dusk`:
```
.PHP Fatal error:  Cannot redeclare php_cs_fixer() (previously declared in /Users/rf/workspace/pmp/vendor/bgaze/laravel-php-cs-fixer/src/helpers.php:14) in /Users/rf/workspace/pmp/vendor/bgaze/laravel-php-cs-fixer/src/helpers.php on line 14
PHP Fatal error:  Uncaught Illuminate\Contracts\Container\BindingResolutionException: Target [Illuminate\Contracts\Debug\ExceptionHandler] is not instantiable. in /Users/rf/workspace/pmp/vendor/laravel/framework/src/Illuminate/Container/Container.php:945
Stack trace:
#0 /Users/rf/workspace/pmp/vendor/laravel/framework/src/Illuminate/Container/Container.php(785): Illuminate\Container\Container->notInstantiable('Illuminate\\Cont...')
#1 /Users/rf/workspace/pmp/vendor/laravel/framework/src/Illuminate/Container/Container.php(658): Illuminate\Container\Container->build('Illuminate\\Cont...')
#2 /Users/rf/workspace/pmp/vendor/laravel/framework/src/Illuminate/Container/Container.php(609): Illuminate\Container\Container->resolve('Illuminate\\Cont...', Array)
#3 /Users/rf/workspace/pmp/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(733): Illuminate\Container\Container->make('Illuminate\\Cont...', Array)
#4 /Users/rf/workspace/pmp/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(159): in /Users/rf/workspace/pmp/vendor/laravel/framework/src/Illuminate/Container/Container.php on line 945
```